### PR TITLE
Tidied up attribute 'type'.

### DIFF
--- a/lib/Business/CardInfo.pm
+++ b/lib/Business/CardInfo.pm
@@ -1,5 +1,6 @@
 package Business::CardInfo;
 use Moose;
+use MooseX::StrictConstructor;
 use Moose::Util::TypeConstraints;
 
 our $VERSION = '0.12';
@@ -35,8 +36,9 @@ has 'number' => (
 
 has 'type' => (
   isa => 'Str',
-  is  => 'rw',
+  is  => 'ro',
   lazy_build => 1,
+  init_arg => undef,
 );
 
 sub _build_type {

--- a/t/01-cardtype.t
+++ b/t/01-cardtype.t
@@ -3,6 +3,9 @@
 use Test::More qw(no_plan);
 use Business::CardInfo;
 
+eval { Business::CardInfo->new(number => '4929 0000 0000 6', type => 'DUMMY') };
+like($@, qr/Found unknown/);
+
 my $bc = Business::CardInfo->new(number => '4929 0000 0000 6');
 is($bc->type,'Visa');
 $bc->number('5404 0000 0000 0001');


### PR DESCRIPTION
Hi @wreis 

I received the distribution as part of December assignment for Pull Request Club.

In this PR, I proposed to make the attribute 'type' more strict. As currently user can set the 'type' attribute in the constructor which gets overridden and ignored silently. I proposed to make the attribute "readonly" and stop user setting in the constructor. 

Using init_arg => undef, we can ignore any value provided by the constructor.  However it still didn't warn the user. I came across very handy MooseX::StrictConstructor that does the job very nicely.

Please let me know if you want to make any changes to my proposals. I am more than happy to change it as per your taste as it is your baby.

Best Regards,
Mohammad S Anwar 